### PR TITLE
Allow tabnet_fit from a pretrained model

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # tabnet (development version)
 
+* Fixed bug in GPU training. (#22)
+* Added GPU CI. (#22)
+
 # tabnet 0.1.0
 
 * Added a `NEWS.md` file to track changes to the package.

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@
 * Fixed bug in GPU training. (#22)
 * Added GPU CI. (#22)
 * Explicit error in case of missing values (@cregouby, #24)
+* Allow model fine-tuning through passing a pre-trained model to tabnet_fit() (@cregouby, #26)
 
 # tabnet 0.1.0
 

--- a/R/hardhat.R
+++ b/R/hardhat.R
@@ -113,6 +113,13 @@ tabnet_bridge <- function(processed, config = tabnet_config(), tabnet_model) {
   stopifnot("tabnet_model is not recognised as a proper TabNet model"= (is.null(tabnet_model) | inherits(tabnet_model, "tabnet_fit")))
   if (is.null(tabnet_model)) {
     tabnet_model <- tabnet_initialize(predictors, outcomes, config = config)
+  } else {
+    if (check_net_is_empty_ptr(tabnet_model)) {
+      m <- reload_model(tabnet_model$serialized_net)
+      # this modifies 'object' in-place so subsequent predicts won't
+      # need to reload.
+      tabnet_model$fit$network$load_state_dict(m$state_dict())
+    }
   }
   fit <- tabnet_train_supervised(tabnet_model, predictors, outcomes, config = config)
   new_tabnet_fit(fit, blueprint = processed$blueprint)

--- a/R/hardhat.R
+++ b/R/hardhat.R
@@ -108,7 +108,8 @@ new_tabnet_fit <- function(fit, blueprint) {
 tabnet_bridge <- function(processed, config = tabnet_config()) {
   predictors <- processed$predictors
   outcomes <- processed$outcomes
-  fit <- tabnet_impl(predictors, outcomes, config = config)
+  initialized <- tabnet_initialize(predictors, outcomes, config = config)
+  fit <- tabnet_train_supervised(initialized, predictors, outcomes, config = config)
   new_tabnet_fit(fit, blueprint = processed$blueprint)
 }
 

--- a/R/hardhat.R
+++ b/R/hardhat.R
@@ -26,14 +26,25 @@
 #'
 #' @param formula A formula specifying the outcome terms on the left-hand side,
 #'  and the predictor terms on the right-hand side.
-#' @param tabnet_model A previously trained TabNet model object you want to continue the fitting on.
-#'  if {\code NULL} (the default) a brand new model is initialized.
+#' @param tabnet_model A previously fitted TabNet model object to continue the fitting on.
+#'  if `NULL` (the default) a brand new model is initialized.
+#' @param from_epoch When a `tabnet_model` is provided, restore the network weights from a specific epoch.
+#'  Default is last available checkpoint for restored model, or last epoch for in-memory model.
 #' @param ... Model hyperparameters. See [tabnet_config()] for a list of
 #'  all possible hyperparameters.
 #'
+#' @section Fitting a pre-trained model:
+#'
+#' When providing a parent `tabnet_model` parameter, the model fitting resumes from that model weights
+#' at the following epoch:
+#'    * last fitted epoch for a model already in torch context
+#'    * Last model checkpoint epoch for a model loaded from file
+#'    * the epoch related to a checkpoint matching or preceding the `from_epoch` value if provided
+#' The model fitting metrics append on top of the parent metrics in the returned TabNet model.
+#'
 #' @section Threading:
 #'
-#' TabNet uses `torch` as it's backend for computation and `torch` uses all
+#' TabNet uses `torch` as its backend for computation and `torch` uses all
 #' available threads by default.
 #'
 #' You can control the number of threads used by `torch` with:
@@ -49,7 +60,7 @@
 #' fit <- tabnet_fit(Sale_Price ~ ., data = ames, epochs = 1)
 #' }
 #'
-#' @return A TabNet model object. It can be used for serialization and predictions.
+#' @return A TabNet model object. It can be used for serialization, predictions, or further fitting.
 #'
 #' @export
 tabnet_fit <- function(x, ...) {
@@ -67,15 +78,15 @@ tabnet_fit.default <- function(x, ...) {
 
 #' @export
 #' @rdname tabnet_fit
-tabnet_fit.data.frame <- function(x, y, tabnet_model=NULL, ...) {
+tabnet_fit.data.frame <- function(x, y, tabnet_model = NULL, ..., from_epoch = NULL) {
   processed <- hardhat::mold(x, y)
   config <- do.call(tabnet_config, list(...))
-  tabnet_bridge(processed, config = config, tabnet_model)
+  tabnet_bridge(processed, config = config, tabnet_model, from_epoch)
 }
 
 #' @export
 #' @rdname tabnet_fit
-tabnet_fit.formula <- function(formula, data, tabnet_model=NULL, ...) {
+tabnet_fit.formula <- function(formula, data, tabnet_model = NULL, ..., from_epoch = NULL) {
   processed <- hardhat::mold(
     formula, data,
     blueprint = hardhat::default_formula_blueprint(
@@ -84,15 +95,15 @@ tabnet_fit.formula <- function(formula, data, tabnet_model=NULL, ...) {
     )
   )
   config <- do.call(tabnet_config, list(...))
-  tabnet_bridge(processed, config = config, tabnet_model)
+  tabnet_bridge(processed, config = config, tabnet_model, from_epoch)
 }
 
 #' @export
 #' @rdname tabnet_fit
-tabnet_fit.recipe <- function(x, data, tabnet_model=NULL, ...) {
+tabnet_fit.recipe <- function(x, data, tabnet_model = NULL, ..., from_epoch = NULL) {
   processed <- hardhat::mold(x, data)
   config <- do.call(tabnet_config, list(...))
-  tabnet_bridge(processed, config = config, tabnet_model)
+  tabnet_bridge(processed, config = config, tabnet_model, from_epoch)
 }
 
 new_tabnet_fit <- function(fit, blueprint) {
@@ -107,22 +118,52 @@ new_tabnet_fit <- function(fit, blueprint) {
   )
 }
 
-tabnet_bridge <- function(processed, config = tabnet_config(), tabnet_model) {
+tabnet_bridge <- function(processed, config = tabnet_config(), tabnet_model, from_epoch) {
   predictors <- processed$predictors
   outcomes <- processed$outcomes
-  stopifnot("tabnet_model is not recognised as a proper TabNet model"= (is.null(tabnet_model) | inherits(tabnet_model, "tabnet_fit")))
+  if (!(is.null(tabnet_model) | inherits(tabnet_model, "tabnet_fit")))
+    rlang::abort("tabnet_model is not recognised as a proper TabNet model")
+
   if (is.null(tabnet_model)) {
+    # new model needs network initialization
+
     tabnet_model_lst <- tabnet_initialize(predictors, outcomes, config = config)
     tabnet_model <- new_tabnet_fit(tabnet_model_lst, blueprint = processed$blueprint)
-  } else {
-    if (check_net_is_empty_ptr(tabnet_model)) {
-      m <- reload_model(tabnet_model$serialized_net)
-      # this modifies 'object' in-place so subsequent predicts won't
-      # need to reload.
-      tabnet_model$fit$network$load_state_dict(m$state_dict())
-    }
-  }
-  fit_lst <- tabnet_train_supervised(tabnet_model, predictors, outcomes, config = config)
+    epoch_shift <- 0L
+
+  } else if (!is.null(from_epoch)) {
+    # model must be loaded from checkpoint
+
+    if (from_epoch > (length(tabnet_model$fit$checkpoints) * tabnet_model$fit$config$checkpoint_epoch))
+      rlang::abort(paste0("The model was trained for less than ", from_epoch, " epochs"))
+
+    # find closest checkpoint for that epoch
+    closest_checkpoint <- from_epoch %/% tabnet_model$fit$config$checkpoint_epoch
+
+    tabnet_model$fit$network <- reload_model(tabnet_model$fit$checkpoints[[closest_checkpoint]])
+    epoch_shift <- closest_checkpoint * tabnet_model$fit$config$checkpoint_epoch
+
+  } else if (!check_net_is_empty_ptr(tabnet_model)) {
+    # model is available from tabnet_model$serialized_net
+
+    m <- reload_model(tabnet_model$serialized_net)
+    # this modifies 'tabnet_model' in-place so subsequent predicts won't
+    # need to reload.
+    tabnet_model$fit$network$load_state_dict(m$state_dict())
+    epoch_shift <- length(tabnet_model$fit$metrics)
+
+  } else if (length(tabnet_model$fit$checkpoints)) {
+    # model is loaded from the last available checkpoint
+
+    last_checkpoint <- length(tabnet_model$fit$checkpoints)
+
+    tabnet_model$fit$network <- reload_model(tabnet_model$fit$checkpoints[[last_checkpoint]])
+    epoch_shift <- last_checkpoint * tabnet_model$fit$config$checkpoint_epoch
+
+  } else rlang::abort(paste0("No model serialized weight can be found in ", tabnet_model, ", check the model history"))
+
+
+  fit_lst <- tabnet_train_supervised(tabnet_model, predictors, outcomes, config = config, epoch_shift)
   new_tabnet_fit(fit_lst, blueprint = processed$blueprint)
 }
 

--- a/R/model.R
+++ b/R/model.R
@@ -302,8 +302,8 @@ tabnet_initialize <- function(x, y, config = tabnet_config()) {
 }
 
 tabnet_train_supervised <- function(obj, x, y, config = tabnet_config()) {
-
-  stopifnot("obj shall be initialised or pretrained"= length(obj$network) > 0)
+  # TODO BUG `obj` coming directly from `tabnet_initialize` is not at all a tabnet_fit object, so different schemas
+  stopifnot("tabnet_model shall be initialised or pretrained"= (length(obj$network) > 0))
   torch::torch_manual_seed(sample.int(1e6, 1))
   has_valid <- config$valid_split > 0
 

--- a/R/model.R
+++ b/R/model.R
@@ -214,8 +214,95 @@ transpose_metrics <- function(metrics) {
   out
 }
 
-tabnet_impl <- function(x, y, config = tabnet_config()) {
+tabnet_initialize <- function(x, y, config = tabnet_config()) {
 
+  torch::torch_manual_seed(sample.int(1e6, 1))
+  has_valid <- config$valid_split > 0
+
+  if (config$device == "auto") {
+    if (torch::cuda_is_available())
+      device <- "cuda"
+    else
+      device <- "cpu"
+  } else {
+    device <- config$device
+  }
+
+  if (has_valid) {
+    n <- nrow(x)
+    valid_idx <- sample.int(n, n*config$valid_split)
+
+    if (is.data.frame(y)) {
+      valid_y <- y[valid_idx,]
+      train_y <- y[-valid_idx,]
+    } else if (is.numeric(y) || is.factor(y)) {
+      valid_y <- y[valid_idx]
+      train_y <- y[-valid_idx]
+    }
+
+    valid_data <- list(x = x[valid_idx, ], y = valid_y)
+    x <- x[-valid_idx, ]
+    y <- train_y
+  }
+
+  # training data
+  data <- resolve_data(x, y)
+
+  # resolve loss
+  if (config$loss == "auto") {
+    if (data$y$dtype == torch::torch_long())
+      config$loss <- "cross_entropy"
+    else
+      config$loss <- "mse"
+  }
+
+  if (config$loss == "mse")
+    config$loss_fn <- torch::nn_mse_loss()
+  else if (config$loss %in% c("bce", "cross_entropy"))
+    config$loss_fn <- torch::nn_cross_entropy_loss()
+
+  # create network
+  network <- tabnet_nn(
+    input_dim = data$input_dim,
+    output_dim = data$output_dim,
+    cat_idxs = data$cat_idx,
+    cat_dims = data$cat_dims,
+    n_d = config$n_d,
+    n_a = config$n_a,
+    n_steps = config$n_steps,
+    gamma = config$gamma,
+    virtual_batch_size = config$virtual_batch_size,
+    cat_emb_dim = config$cat_emb_dim,
+    n_independent = config$n_independent,
+    n_shared = config$n_shared,
+    momentum = config$momentum
+  )
+
+  network$to(device = device)
+
+
+  # main loop
+  metrics <- list()
+  checkpoints <- list()
+
+
+  importances <- tibble::tibble(
+    variables = colnames(x),
+    importance = NA
+  )
+
+  list(
+    network = network,
+    metrics = metrics,
+    config = config,
+    checkpoints = checkpoints,
+    importances = importances
+  )
+}
+
+tabnet_train_supervised <- function(obj, x, y, config = tabnet_config()) {
+
+  stopifnot("obj shall be initialised or pretrained"= length(obj$network) > 0)
   torch::torch_manual_seed(sample.int(1e6, 1))
   has_valid <- config$valid_split > 0
 
@@ -278,22 +365,8 @@ tabnet_impl <- function(x, y, config = tabnet_config()) {
   else if (config$loss %in% c("bce", "cross_entropy"))
     config$loss_fn <- torch::nn_cross_entropy_loss()
 
-  # create network
-  network <- tabnet_nn(
-    input_dim = data$input_dim,
-    output_dim = data$output_dim,
-    cat_idxs = data$cat_idx,
-    cat_dims = data$cat_dims,
-    n_d = config$n_d,
-    n_a = config$n_a,
-    n_steps = config$n_steps,
-    gamma = config$gamma,
-    virtual_batch_size = config$virtual_batch_size,
-    cat_emb_dim = config$cat_emb_dim,
-    n_independent = config$n_independent,
-    n_shared = config$n_shared,
-    momentum = config$momentum
-  )
+  # restore network
+  network <- obj$network
 
   network$to(device = device)
 
@@ -323,10 +396,11 @@ tabnet_impl <- function(x, y, config = tabnet_config()) {
   }
 
   # main loop
-  metrics <- list()
-  checkpoints <- list()
+  metrics <- obj$metric
+  checkpoints <- obj$checkpoints
+  epoch_shift <- length(metrics)
 
-  for (epoch in seq_len(config$epochs)) {
+  for (epoch in seq_len(config$epochs)+epoch_shift) {
 
     metrics[[epoch]] <- list(train = NULL, valid = NULL)
     train_metrics <- c()
@@ -420,5 +494,5 @@ predict_impl_class <- function(obj, x) {
   p <- get_blueprint_levels(obj)[p]
   p <- factor(p, levels = get_blueprint_levels(obj))
   hardhat::spruce_class(p)
-}
 
+}

--- a/man/tabnet.Rd
+++ b/man/tabnet.Rd
@@ -72,7 +72,7 @@ Parsnip compatible tabnet model
 \section{Threading}{
 
 
-TabNet uses \code{torch} as it's backend for computation and \code{torch} uses all
+TabNet uses \code{torch} as its backend for computation and \code{torch} uses all
 available threads by default.
 
 You can control the number of threads used by \code{torch} with:\preformatted{torch::torch_set_num_threads(1)

--- a/man/tabnet_fit.Rd
+++ b/man/tabnet_fit.Rd
@@ -12,11 +12,11 @@ tabnet_fit(x, ...)
 
 \method{tabnet_fit}{default}(x, ...)
 
-\method{tabnet_fit}{data.frame}(x, y, tabnet_model = NULL, ...)
+\method{tabnet_fit}{data.frame}(x, y, tabnet_model = NULL, ..., from_epoch = NULL)
 
-\method{tabnet_fit}{formula}(formula, data, tabnet_model = NULL, ...)
+\method{tabnet_fit}{formula}(formula, data, tabnet_model = NULL, ..., from_epoch = NULL)
 
-\method{tabnet_fit}{recipe}(x, data, tabnet_model = NULL, ...)
+\method{tabnet_fit}{recipe}(x, data, tabnet_model = NULL, ..., from_epoch = NULL)
 }
 \arguments{
 \item{x}{Depending on the context:
@@ -42,8 +42,11 @@ specified as:
 \item A numeric \strong{vector}.
 }}
 
-\item{tabnet_model}{A previously trained TabNet model object you want to continue the fitting on.
-if {\code NULL} (the default) a brand new model is initialized.}
+\item{tabnet_model}{A previously fitted TabNet model object to continue the fitting on.
+if \code{NULL} (the default) a brand new model is initialized.}
+
+\item{from_epoch}{When a \code{tabnet_model} is provided, restore the network weights from a specific epoch.
+Default is last available checkpoint for restored model, or last epoch for in-memory model.}
 
 \item{formula}{A formula specifying the outcome terms on the left-hand side,
 and the predictor terms on the right-hand side.}
@@ -54,15 +57,28 @@ and the predictor terms on the right-hand side.}
 }}
 }
 \value{
-A TabNet model object. It can be used for serialization and predictions.
+A TabNet model object. It can be used for serialization, predictions, or further fitting.
 }
 \description{
 Fits the \href{https://arxiv.org/abs/1908.07442}{TabNet: Attentive Interpretable Tabular Learning} model
 }
+\section{Fitting a pre-trained model}{
+
+
+When providing a parent \code{tabnet_model} parameter, the model fitting resumes from that model weights
+at the following epoch:
+\itemize{
+\item last fitted epoch for a model already in torch context
+\item Last model checkpoint epoch for a model loaded from file
+\item the epoch related to a checkpoint matching or preceding the \code{from_epoch} value if provided
+The model fitting metrics append on top of the parent metrics in the returned TabNet model.
+}
+}
+
 \section{Threading}{
 
 
-TabNet uses \code{torch} as it's backend for computation and \code{torch} uses all
+TabNet uses \code{torch} as its backend for computation and \code{torch} uses all
 available threads by default.
 
 You can control the number of threads used by \code{torch} with:\preformatted{torch::torch_set_num_threads(1)

--- a/tests/testthat/test-hardhat-scenarios.R
+++ b/tests/testthat/test-hardhat-scenarios.R
@@ -1,12 +1,10 @@
 
-
 test_that("we can continue training with a additional fit", {
 
   data("ames", package = "modeldata")
 
   x <- ames[-which(names(ames) == "Sale_Price")]
   y <- ames$Sale_Price
-
   fit_1 <- tabnet_fit(x, y, epochs = 1)
   fit_2 <- tabnet_fit(x, y, fit_1, epochs = 1)
 
@@ -15,3 +13,16 @@ test_that("we can continue training with a additional fit", {
 
 })
 
+test_that("we can change the tabnet_options between training epoch", {
+
+  data("ames", package = "modeldata")
+
+  x <- ames[-which(names(ames) == "Sale_Price")]
+  y <- ames$Sale_Price
+  fit_1 <- tabnet_fit(x, y, epochs = 1)
+  fit_2 <- tabnet_fit(x, y, fit_2, epochs = 1, penalty = 0.003, learn_rate = 0.002)
+
+  expect_equal(fit_3$fit$config$epoch, 3)
+  expect_lte(mean(fit_2$fit$metrics[[2]]$train$loss), mean(fit_2$fit$metrics[[1]]$train$loss))
+
+})

--- a/tests/testthat/test-hardhat-scenarios.R
+++ b/tests/testthat/test-hardhat-scenarios.R
@@ -1,0 +1,17 @@
+
+
+test_that("we can continue training with a additional fit", {
+
+  data("ames", package = "modeldata")
+
+  x <- ames[-which(names(ames) == "Sale_Price")]
+  y <- ames$Sale_Price
+
+  fit_1 <- tabnet_fit(x, y, epochs = 1)
+  fit_2 <- tabnet_fit(x, y, fit_1, epochs = 1)
+
+  expect_equal(fit_2$fit$config$epoch, 2)
+  expect_lte(mean(fit_2$fit$metrics[[2]]$train$loss), mean(fit_2$fit$metrics[[1]]$train$loss))
+
+})
+

--- a/tests/testthat/test-hardhat-scenarios.R
+++ b/tests/testthat/test-hardhat-scenarios.R
@@ -1,27 +1,51 @@
 test_that("we can continue training with a additional fit", {
 
   data("ames", package = "modeldata")
+  ids <- sample(nrow(ames), 256)
+  x <- ames[ids,-which(names(ames) == "Sale_Price")]
+  y <- ames[ids,]$Sale_Price
 
-  x <- ames[-which(names(ames) == "Sale_Price")]
-  y <- ames$Sale_Price
   fit_1 <- tabnet_fit(x, y, epochs = 1)
-  fit_2 <- tabnet_fit(x, y, fit_1, epochs = 1)
+  fit_2 <- tabnet_fit(x, y, tabnet_model=fit_1, epochs = 1)
 
-  expect_equal(fit_2$fit$config$epoch, 2)
-  expect_lte(mean(fit_2$fit$metrics[[2]]$train$loss), mean(fit_2$fit$metrics[[1]]$train$loss))
+  expect_equal(fit_2$fit$config$epoch, 1)
+  expect_length(fit_2$fit$metrics, 2)
+  expect_identical(fit_1$fit$metrics[[1]]$train$loss, fit_2$fit$metrics[[1]]$train$loss)
 
 })
 
 test_that("we can change the tabnet_options between training epoch", {
 
   data("ames", package = "modeldata")
+  ids <- sample(nrow(ames), 256)
+  x <- ames[ids,-which(names(ames) == "Sale_Price")]
+  y <- ames[ids,]$Sale_Price
 
-  x <- ames[-which(names(ames) == "Sale_Price")]
-  y <- ames$Sale_Price
   fit_1 <- tabnet_fit(x, y, epochs = 1)
-  fit_2 <- tabnet_fit(x, y, fit_2, epochs = 1, penalty = 0.003, learn_rate = 0.002)
+  fit_2 <- tabnet_fit(x, y, fit_1, epochs = 1, penalty = 0.003, learn_rate = 0.002)
 
-  expect_equal(fit_3$fit$config$epoch, 3)
-  expect_lte(mean(fit_2$fit$metrics[[2]]$train$loss), mean(fit_2$fit$metrics[[1]]$train$loss))
+  expect_equal(fit_2$fit$config$epoch, 1)
+  expect_length(fit_2$fit$metrics, 2)
+  expect_equal(fit_2$fit$config$learn_rate, 0.002)
+
+})
+
+test_that("epoch counter is valid for retraining from a checkpoint", {
+
+  data("ames", package = "modeldata")
+  ids <- sample(nrow(ames), 256)
+  x <- ames[ids,-which(names(ames) == "Sale_Price")]
+  y <- ames[ids,]$Sale_Price
+
+  fit_1 <- tabnet_fit(x, y, epochs = 12, verbose=T)
+  tmp <- tempfile("model", fileext = "rds")
+  saveRDS(fit_1, tmp)
+
+  fit1 <- readRDS(tmp)
+  fit_2 <- tabnet_fit(x, y, fit1, epochs = 12, verbose=T)
+
+  expect_equal(fit_2$fit$config$epoch, 12)
+  expect_length(fit_2$fit$metrics, 22)
+  expect_lte(mean(fit_2$fit$metrics[[22]]$train$loss), mean(fit_2$fit$metrics[[1]]$train$loss))
 
 })


### PR DESCRIPTION
Model management infrastructure now splits between network intialisation with `tabnet_initialize()` and network fitting with `tabnet_train_supervised()`.
This fix #25