### PR TITLE
Fix tests

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -43,3 +43,5 @@ Suggests:
     tidyr,
     purrr
 VignetteBuilder: knitr
+Remotes:
+    mlverse/torch@bugfix/restore-correct-requires_grad

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,7 +17,7 @@ RoxygenNote: 7.1.1
 URL: https://github.com/mlverse/tabnet
 BugReports: https://github.com/mlverse/tabnet/issues
 Imports: 
-    torch,
+    torch (>= 0.3.0.9001),
     hardhat,
     magrittr,
     glue,
@@ -44,4 +44,4 @@ Suggests:
     purrr
 VignetteBuilder: knitr
 Remotes:
-    mlverse/torch@bugfix/restore-correct-requires_grad
+    mlverse/torch

--- a/R/model.R
+++ b/R/model.R
@@ -63,7 +63,7 @@ resolve_data <- function(x, y) {
 #'   A value close to 1 will make mask selection least correlated between layers.
 #'   Values range from 1.0 to 2.0.
 #' @param mask_type (character) Final layer of feature selector in the attentive_transformer
-#'   block, either ["sparsemax"] or ["entmax"].Defaults to ["sparsemax"].
+#'   block, either `"sparsemax"` or `"entmax"`.Defaults to `"sparsemax"`.
 #' @param virtual_batch_size (int) Size of the mini batches used for
 #'   "Ghost Batch Normalization" (default=128)
 #' @param learn_rate initial learning rate for the optimizer.

--- a/man/tabnet_config.Rd
+++ b/man/tabnet_config.Rd
@@ -69,7 +69,7 @@ A value close to 1 will make mask selection least correlated between layers.
 Values range from 1.0 to 2.0.}
 
 \item{mask_type}{(character) Final layer of feature selector in the attentive_transformer
-block, either \link{"sparsemax"} or \link{"entmax"}.Defaults to \link{"sparsemax"}.}
+block, either \code{"sparsemax"} or \code{"entmax"}.Defaults to \code{"sparsemax"}.}
 
 \item{virtual_batch_size}{(int) Size of the mini batches used for
 "Ghost Batch Normalization" (default=128)}

--- a/tests/testthat/_snaps/hardhat.md
+++ b/tests/testthat/_snaps/hardhat.md
@@ -3,20 +3,20 @@
     An `nn_module` containing 10,742 parameters.
     
     ── Modules ───────────────────────────────────────
-    ● embedder: <embedding_generator> #283 parameters
-    ● tabnet: <tabnet_no_embedding> #10,458 parameters
+    • embedder: <embedding_generator> #283 parameters
+    • tabnet: <tabnet_no_embedding> #10,458 parameters
     
     ── Parameters ────────────────────────────────────
-    ● .check: Float [1:1]
+    • .check: Float [1:1]
 
 ---
 
     An `nn_module` containing 10,742 parameters.
     
     ── Modules ───────────────────────────────────────
-    ● embedder: <embedding_generator> #283 parameters
-    ● tabnet: <tabnet_no_embedding> #10,458 parameters
+    • embedder: <embedding_generator> #283 parameters
+    • tabnet: <tabnet_no_embedding> #10,458 parameters
     
     ── Parameters ────────────────────────────────────
-    ● .check: Float [1:1]
+    • .check: Float [1:1]
 

--- a/tests/testthat/_snaps/unsupervised.md
+++ b/tests/testthat/_snaps/unsupervised.md
@@ -3,12 +3,12 @@
     An `nn_module` containing 13,894 parameters.
     
     ── Modules ───────────────────────────────────────
-    ● initial_bn: <nn_batch_norm1d> #146 parameters
-    ● embedder: <embedding_generator> #283 parameters
-    ● masker: <random_obfuscator> #0 parameters
-    ● encoder: <tabnet_encoder> #10,304 parameters
-    ● decoder: <tabnet_decoder> #3,160 parameters
+    • initial_bn: <nn_batch_norm1d> #146 parameters
+    • embedder: <embedding_generator> #283 parameters
+    • masker: <random_obfuscator> #0 parameters
+    • encoder: <tabnet_encoder> #10,304 parameters
+    • decoder: <tabnet_decoder> #3,160 parameters
     
     ── Parameters ────────────────────────────────────
-    ● .check: Float [1:1]
+    • .check: Float [1:1]
 


### PR DESCRIPTION
This fix tests by:

- Updating snapshots fro the new `cli` release
- Uses a torch version that fixes a bug where it was not possible to train models using the `from_epoch` parameter because reloaded models had `requires_grad=FALSE`. I couldn't find out when this broke.. It seems to me that this was a hidden error, as torch 0.2.1 would also fail to load the parameters correctly.