### PR TITLE
Bugfix/#35 other losses

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,14 +2,14 @@
 
 ## New features
 
-* Allow model fine-tuning through passing a pre-trained model to tabnet_fit() (@cregouby, #26)
+* Allow model fine-tuning through passing a pre-trained model to `tabnet_fit()` (@cregouby, #26)
 * Explicit error in case of missing values (@cregouby, #24)
-* Better handling of larger datasets when running `tabnet_explain`.
-* Add tabnet_pretrain() for unsupervised pretraining (@cregouby, #29)
-* Add autoplot() of model loss among epochs (@cregouby, #36)
-* Added a `config` argument to fit/pretrain functions so one can pass a pre-made config list. (#42)
-* Add `mask_type` configuration option with `entmax` additional to `sparsemax` (@cmcmaster1, #48)
-* Allow `tabnet_config(loss=)` to be a function (@cregouby, #55)
+* Better handling of larger datasets when running `tabnet_explain()`.
+* Add `tabnet_pretrain()` for unsupervised pretraining (@cregouby, #29)
+* Add `autoplot()` of model loss among epochs (@cregouby, #36)
+* Added a `config` argument to `fit() / pretrain()` so one can pass a pre-made config list. (#42)
+* In `tabnet_config()`, new `mask_type` option with `entmax` additional to default `sparsemax` (@cmcmaster1, #48)
+* In `tabnet_config()`, `loss` now also takes function (@cregouby, #55)
 
 ## Bugfixes
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,7 @@
 * Add autoplot() of model loss among epochs (@cregouby, #36)
 * Added a `config` argument to fit/pretrain functions so one can pass a pre-made config list. (#42)
 * Add `mask_type` configuration option with `entmax` additional to `sparsemax` (@cmcmaster1, #48)
+* Allow `tabnet_config(loss=)` to be a function (@cregouby, #55)
 
 ## Bugfixes
 

--- a/R/model.R
+++ b/R/model.R
@@ -172,21 +172,14 @@ tabnet_config <- function(batch_size = 256,
 }
 
 resolve_loss <- function(loss, dtype) {
-  if (loss == "auto") {
-    if (dtype == torch::torch_long())
-      loss <- "cross_entropy"
-    else
-      loss <- "mse"
-  }
-
   if (is.function(loss))
     loss_fn <- loss
-  else if (loss == "mse" && !dtype == torch::torch_long())
+  else if (loss %in% c("mse", "auto") && !dtype == torch::torch_long())
     loss_fn <- torch::nn_mse_loss()
-  else if (loss %in% c("bce", "cross_entropy") && dtype == torch::torch_long())
+  else if (loss %in% c("bce", "cross_entropy", "auto") && dtype == torch::torch_long())
     loss_fn <- torch::nn_cross_entropy_loss()
   else
-    rlang::abort(paste0(loss," is not available for outcome of type ",dtype))
+    rlang::abort(paste0(loss," is not a valid loss for outcome of type ",dtype))
 
   loss_fn
 }

--- a/R/model.R
+++ b/R/model.R
@@ -440,10 +440,10 @@ tabnet_train_supervised <- function(obj, x, y, config = tabnet_config(), epoch_s
 
     network$eval()
     if (has_valid) {
-      for (batch in torch::enumerate(valid_dl)) {
+      coro::loop(for (batch in valid_dl) {
         m <- valid_batch(network, batch_to_device(batch, device), config)
         valid_metrics <- c(valid_metrics, m)
-      }
+      })
       metrics[[epoch]][["valid"]] <- transpose_metrics(valid_metrics)
     }
 

--- a/tests/testthat/test-hardhat.R
+++ b/tests/testthat/test-hardhat.R
@@ -356,6 +356,7 @@ test_that("fit works with entmax mask-type", {
   )
 
 })
+
 test_that("fit raise an error with non-supported mask-type", {
 
   library(recipes)
@@ -371,3 +372,72 @@ test_that("fit raise an error with non-supported mask-type", {
   )
 
 })
+
+test_that("config$loss=`auto` adapt to recipe outcome str()", {
+
+  library(recipes)
+  data("attrition", package = "modeldata")
+  ids <- sample(nrow(attrition), 256)
+
+  # nominal outcome
+  rec <- recipe(EnvironmentSatisfaction ~ ., data = attrition[ids, ]) %>%
+    step_normalize(all_numeric(), -all_outcomes())
+  fit_auto <- tabnet_fit(rec, attrition, epochs = 1, verbose = TRUE,
+                      config = tabnet_config( loss="auto"))
+  expect_equal(fit_auto$fit$config$loss_fn, torch::nn_cross_entropy_loss())
+
+  # numerical outcome
+  rec <- recipe(MonthlyIncome ~ ., data = attrition[ids, ]) %>%
+    step_normalize(all_numeric(), -all_outcomes())
+  fit_auto <- tabnet_fit(rec, attrition, epochs = 1, verbose = TRUE,
+                      config = tabnet_config( loss="auto"))
+  expect_equal(fit_auto$fit$config$loss_fn, torch::nn_mse_loss())
+
+})
+
+test_that("config$loss not adapted to recipe outcome raise an explicit error", {
+
+  library(recipes)
+  data("attrition", package = "modeldata")
+  ids <- sample(nrow(attrition), 256)
+
+  # nominal outcome with numerical loss
+  rec <- recipe(EnvironmentSatisfaction ~ ., data = attrition[ids, ]) %>%
+    step_normalize(all_numeric(), -all_outcomes())
+  fit_auto <- tabnet_fit(rec, attrition, epochs = 1, verbose = TRUE,
+                      config = tabnet_config( loss="mse"))
+  expect_equal(fit_auto$fit$config$loss_fn, torch::nn_mse_loss())
+
+  # numerical outcome
+  rec <- recipe(MonthlyIncome ~ ., data = attrition[ids, ]) %>%
+    step_normalize(all_numeric(), -all_outcomes())
+  fit_auto <- tabnet_fit(rec, attrition, epochs = 1, verbose = TRUE,
+                      config = tabnet_config( loss="cross_entropy"))
+  expect_equal(fit_auto$fit$config$loss_fn, torch::nn_cross_entropy_loss())
+
+})
+
+
+test_that("config$loss can be a function", {
+
+  library(recipes)
+  data("attrition", package = "modeldata")
+  ids <- sample(nrow(attrition), 256)
+
+  # nominal outcome loss
+  rec <- recipe(EnvironmentSatisfaction ~ ., data = attrition[ids, ]) %>%
+    step_normalize(all_numeric(), -all_outcomes())
+  fit_auto <- tabnet_fit(rec, attrition, epochs = 1, verbose = TRUE,
+                      config = tabnet_config( loss=torch::nn_kl_div_loss()))
+  expect_equal(fit_auto$fit$config$loss_fn, torch::nn_kl_div_loss())
+
+  # numerical outcome loss
+  rec <- recipe(MonthlyIncome ~ ., data = attrition[ids, ]) %>%
+    step_normalize(all_numeric(), -all_outcomes())
+  fit_auto <- tabnet_fit(rec, attrition, epochs = 1, verbose = TRUE,
+                      config = tabnet_config( loss=torch::nn_smooth_l1_loss()))
+  expect_equal(fit_auto$fit$config$loss_fn, torch::nn_smooth_l1_loss())
+
+})
+
+

--- a/tests/testthat/test-hardhat.R
+++ b/tests/testthat/test-hardhat.R
@@ -404,17 +404,17 @@ test_that("config$loss not adapted to recipe outcome raise an explicit error", {
   # nominal outcome with numerical loss
   rec <- recipe(EnvironmentSatisfaction ~ ., data = attrition[ids, ]) %>%
     step_normalize(all_numeric(), -all_outcomes())
-  fit_auto <- tabnet_fit(rec, attrition, epochs = 1, verbose = TRUE,
-                      config = tabnet_config( loss="mse"))
-  expect_equal(fit_auto$fit$config$loss_fn, torch::nn_mse_loss())
-
+  expect_error(tabnet_fit(rec, attrition, epochs = 1, verbose = TRUE,
+                          config = tabnet_config( loss="mse")),
+              regexp = "is not a valid loss for outcome of type"
+  )
   # numerical outcome
   rec <- recipe(MonthlyIncome ~ ., data = attrition[ids, ]) %>%
     step_normalize(all_numeric(), -all_outcomes())
-  fit_auto <- tabnet_fit(rec, attrition, epochs = 1, verbose = TRUE,
-                      config = tabnet_config( loss="cross_entropy"))
-  expect_equal(fit_auto$fit$config$loss_fn, torch::nn_cross_entropy_loss())
-
+  expect_error(tabnet_fit(rec, attrition, epochs = 1, verbose = TRUE,
+                      config = tabnet_config( loss="cross_entropy")),
+               regexp = "is not a valid loss for outcome of type"
+  )
 })
 
 
@@ -428,15 +428,15 @@ test_that("config$loss can be a function", {
   rec <- recipe(EnvironmentSatisfaction ~ ., data = attrition[ids, ]) %>%
     step_normalize(all_numeric(), -all_outcomes())
   fit_auto <- tabnet_fit(rec, attrition, epochs = 1, verbose = TRUE,
-                      config = tabnet_config( loss=torch::nn_kl_div_loss()))
-  expect_equal(fit_auto$fit$config$loss_fn, torch::nn_kl_div_loss())
+                      config = tabnet_config( loss=torch::nn_nll_loss()))
+  expect_equivalent(fit_auto$fit$config$loss_fn, torch::nn_nll_loss())
 
   # numerical outcome loss
   rec <- recipe(MonthlyIncome ~ ., data = attrition[ids, ]) %>%
     step_normalize(all_numeric(), -all_outcomes())
   fit_auto <- tabnet_fit(rec, attrition, epochs = 1, verbose = TRUE,
-                      config = tabnet_config( loss=torch::nn_smooth_l1_loss()))
-  expect_equal(fit_auto$fit$config$loss_fn, torch::nn_smooth_l1_loss())
+                      config = tabnet_config( loss=torch::nn_poisson_nll_loss()))
+  expect_equivalent(fit_auto$fit$config$loss_fn, torch::nn_poisson_nll_loss())
 
 })
 


### PR DESCRIPTION
A fix to #35 :
- allow `loss` to be functions
- enforce explicit loss to match outcome dtype