### PR TITLE
Add support for 'reduce_on_plateau' learning rate scheduler

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -6,7 +6,8 @@ Authors@R: c(
     person(family = "RStudio", role = c("cph")),
     person(given = "Christophe", family = "Regouby", role = c("cre", "ctb"), email = "christophe.regouby@free.fr"),
     person(given = "Egill", family = "Fridgeirsson", role = c("ctb")),
-    person(given = "Philipp", family = "Haarmeyer", role = c("ctb"))
+    person(given = "Philipp", family = "Haarmeyer", role = c("ctb")),
+    person(given = "Sven", family = "Verweij", role = c("ctb"),  comment = c(ORCID = "0000-0002-5573-3952"))
     )
 Description: Implements the 'TabNet' model by Sercan O. Arik et al. (2019) <arXiv:1908.07442>
     and provides a consistent interface for fitting and creating predictions. It's

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # tabnet (development version)
 
+## New features
+* Add `reduce_on_plateau` as option for `lr_scheduler` at `tabnet_config()` (@SvenVw, #120)
+
 # tabnet 0.4.0
 
 ## New features

--- a/R/model.R
+++ b/R/model.R
@@ -457,8 +457,12 @@ tabnet_train_supervised <- function(obj, x, y, config = tabnet_config(), epoch_s
     scheduler <- list(step = function() {})
   } else if (rlang::is_function(config$lr_scheduler)) {
     scheduler <- config$lr_scheduler(optimizer)
+  } else if (config$lr_scheduler == "reduce_on_plateau") {
+    scheduler <- torch::lr_reduce_on_plateau(optimizer, factor = config$lr_decay, patience = config$step_size)
   } else if (config$lr_scheduler == "step") {
     scheduler <- torch::lr_step(optimizer, config$step_size, config$lr_decay)
+  } else {
+    rlang::abort("Currently only the 'step' and 'reduce_on_plateau' scheduler are supported.")
   }
 
   # restore previous metrics & checkpoints
@@ -537,8 +541,14 @@ tabnet_train_supervised <- function(obj, x, y, config = tabnet_config(), epoch_s
         best_metric <- current_loss
     }
 
+    if (! is.null(config$lr_scheduler)) {
+      if (config$lr_scheduler == "step") {
+        scheduler$step()
+      } else {
+        scheduler$step(current_loss)
+      }
+    }
 
-    scheduler$step()
   }
 
   network$to(device = "cpu")

--- a/R/model.R
+++ b/R/model.R
@@ -90,9 +90,10 @@ resolve_data <- function(x, y) {
 #'   range from 1 to 5
 #' @param verbose (logical) Whether to print progress and loss values during
 #'   training.
-#' @param lr_scheduler if `NULL`, no learning rate decay is used. if "step"
-#'   decays the learning rate by `lr_decay` every `step_size` epochs. It can
-#'   also be a [torch::lr_scheduler] function that only takes the optimizer
+#' @param lr_scheduler if `NULL`, no learning rate decay is used. If "step"
+#'   decays the learning rate by `lr_decay` every `step_size` epochs. If "reduce_on_plateau"
+#'   decays the learning rate by `lr_decay` when no improvement after `step_size` epochs.
+#'   It can #'   also be a [torch::lr_scheduler] function that only takes the optimizer
 #'   as parameter. The `step` method is called once per epoch.
 #' @param lr_decay multiplies the initial learning rate by `lr_decay` every
 #'   `step_size` epochs. Unused if `lr_scheduler` is a `torch::lr_scheduler`

--- a/R/model.R
+++ b/R/model.R
@@ -542,14 +542,11 @@ tabnet_train_supervised <- function(obj, x, y, config = tabnet_config(), epoch_s
         best_metric <- current_loss
     }
 
-    if (! is.null(config$lr_scheduler)) {
-      if (config$lr_scheduler == "step") {
-        scheduler$step()
-      } else {
-        scheduler$step(current_loss)
-      }
+    if ("metrics" %in% names(formals(scheduler$step))) {
+      scheduler$step(current_loss)
+    } else {
+      scheduler$step()
     }
-
   }
 
   network$to(device = "cpu")

--- a/R/pretraining.R
+++ b/R/pretraining.R
@@ -143,8 +143,12 @@ tabnet_train_unsupervised <- function(x, config = tabnet_config(), epoch_shift =
     scheduler <- list(step = function() {})
   } else if (rlang::is_function(config$lr_scheduler)) {
     scheduler <- config$lr_scheduler(optimizer)
+  } else if (config$lr_scheduler == "reduce_on_plateau") {
+    scheduler <- torch::lr_reduce_on_plateau(optimizer, factor = config$lr_decay, patience = config$step_size)
   } else if (config$lr_scheduler == "step") {
     scheduler <- torch::lr_step(optimizer, config$step_size, config$lr_decay)
+  } else {
+    rlang::abort("Currently only the 'step' and 'reduce_on_plateau' scheduler are supported.")
   }
 
   # initialize metrics & checkpoints
@@ -223,8 +227,13 @@ tabnet_train_unsupervised <- function(x, config = tabnet_config(), epoch_shift =
       best_metric <- current_loss
     }
 
-
-    scheduler$step()
+    if (! is.null(config$lr_scheduler)) {
+      if (config$lr_scheduler == "step") {
+        scheduler$step()
+      } else {
+        scheduler$step(current_loss)
+      }
+    }
   }
 
   network$to(device = "cpu")

--- a/R/pretraining.R
+++ b/R/pretraining.R
@@ -227,12 +227,10 @@ tabnet_train_unsupervised <- function(x, config = tabnet_config(), epoch_shift =
       best_metric <- current_loss
     }
 
-    if (! is.null(config$lr_scheduler)) {
-      if (config$lr_scheduler == "step") {
-        scheduler$step()
-      } else {
-        scheduler$step(current_loss)
-      }
+    if ("metrics" %in% names(formals(scheduler$step))) {
+      scheduler$step(current_loss)
+    } else {
+      scheduler$step()
     }
   }
 

--- a/man/tabnet_config.Rd
+++ b/man/tabnet_config.Rd
@@ -86,9 +86,10 @@ block, either \code{"sparsemax"} or \code{"entmax"}.Defaults to \code{"sparsemax
 \item{optimizer}{the optimization method. currently only 'adam' is supported,
 you can also pass any torch optimizer function.}
 
-\item{lr_scheduler}{if \code{NULL}, no learning rate decay is used. if "step"
-decays the learning rate by \code{lr_decay} every \code{step_size} epochs. It can
-also be a \link[torch:lr_scheduler]{torch::lr_scheduler} function that only takes the optimizer
+\item{lr_scheduler}{if \code{NULL}, no learning rate decay is used. If "step"
+decays the learning rate by \code{lr_decay} every \code{step_size} epochs. If "reduce_on_plateau"
+decays the learning rate by \code{lr_decay} when no improvement after \code{step_size} epochs.
+It can #'   also be a \link[torch:lr_scheduler]{torch::lr_scheduler} function that only takes the optimizer
 as parameter. The \code{step} method is called once per epoch.}
 
 \item{lr_decay}{multiplies the initial learning rate by \code{lr_decay} every

--- a/tests/testthat/test-hardhat_parameters.R
+++ b/tests/testthat/test-hardhat_parameters.R
@@ -82,7 +82,7 @@ test_that("explicit error message when categorical embedding dimension vector ha
   )
 })
 
-test_that("scheduler works", {
+test_that("step scheduler works", {
 
   expect_error(
     fit <- tabnet_fit(x, y, epochs = 3, lr_scheduler = "step",
@@ -102,6 +102,25 @@ test_that("scheduler works", {
 
 })
 
+test_that("reduce_on_plateau scheduler works", {
+
+  expect_error(
+    fit <- tabnet_fit(x, y, epochs = 3, lr_scheduler = "reduce_on_plateau",
+                      lr_decay = 0.1, step_size = 1),
+    regexp = NA
+  )
+
+  sc_fn <- function(optimizer) {
+    torch::lr_step(optimizer, step_size = 1, gamma = 0.1)
+  }
+
+  expect_error(
+    fit <- tabnet_fit(x, y, epochs = 3, lr_scheduler = sc_fn,
+                      lr_decay = 0.1, step_size = 1),
+    regexp = NA
+  )
+
+})
 
 test_that("fit uses config parameters mix from config= and ...", {
 

--- a/tests/testthat/test-pretraining.R
+++ b/tests/testthat/test-pretraining.R
@@ -108,7 +108,7 @@ test_that("can train from a recipe", {
 
 })
 
-test_that("lr scheduler works", {
+test_that("lr scheduler step works", {
 
   expect_error(
     fit <- tabnet_pretrain(x, y, epochs = 3, lr_scheduler = "step",
@@ -123,6 +123,26 @@ test_that("lr scheduler works", {
   expect_error(
     fit <- tabnet_pretrain(x, y, epochs = 3, lr_scheduler = sc_fn,
                       lr_decay = 0.1, step_size = 1),
+    regexp = NA
+  )
+
+})
+
+test_that("lr scheduler reduce_on_plateau works", {
+
+  expect_error(
+    fit <- tabnet_pretrain(x, y, epochs = 3, lr_scheduler = "reduce_on_plateau",
+                           lr_decay = 0.1, step_size = 1),
+    regexp = NA
+  )
+
+  sc_fn <- function(optimizer) {
+    torch::lr_step(optimizer, step_size = 1, gamma = 0.1)
+  }
+
+  expect_error(
+    fit <- tabnet_pretrain(x, y, epochs = 3, lr_scheduler = sc_fn,
+                           lr_decay = 0.1, step_size = 1),
     regexp = NA
   )
 

--- a/tests/testthat/test-pretraining.R
+++ b/tests/testthat/test-pretraining.R
@@ -137,7 +137,7 @@ test_that("lr scheduler reduce_on_plateau works", {
   )
 
   sc_fn <- function(optimizer) {
-    torch::lr_step(optimizer, step_size = 1, gamma = 0.1)
+    torch::lr_reduce_on_plateau(optimizer, factor = 0.1, patience = 10)
   }
 
   expect_error(


### PR DESCRIPTION
Hi there! I've created this pull request to enhance the functionality of the package by adding support for the `reduce_on_plateau` learning rate scheduler. Through my experience with other networks, I've observed that this particular scheduler often leads to improved model performance.

Currently, the documentation states that for the `lr_scheduler` parameter in `tabnet_config`, any other `torch::lr_scheduler` function can be passed. However, when I attempted to do so, I encountered an error. The issue arises because during (pre)training, only `scheduler$step()` is supported, while `reduce_on_plateau` requires the loss as input and thus needs `scheduler$step(loss)`.

By submitting this pull request, I aim to introduce this missing functionality to this nice and usefull package 😃. Please let me know if there's anything else I can provide or do to support this pull request.